### PR TITLE
Clean-up, syntax update and tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ addons/sourcemod/scripting/include
 !addons/sourcemod/scripting/include/socket.inc
 !addons/sourcemod/scripting/include/tf2items.inc
 !addons/sourcemod/scripting/include/tf2attributes.inc
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.smx
+addons/sourcemod/scripting/include
+!addons/sourcemod/scripting/include/steamtools.inc
+!addons/sourcemod/scripting/include/socket.inc
+!addons/sourcemod/scripting/include/tf2items.inc
+!addons/sourcemod/scripting/include/tf2attributes.inc

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ TF2 Tower Defense is a modification to Valve's game Team Fortress 2. Basically y
 
 ### Authors ###
 
-TF2 Tower Defense was originally created by [floube](http://steamcommunity.com/profiles/76561198051789304/) and [mani](http://steamcommunity.com/profiles/76561198002201102/). It is currently maintained by [Hurp Durp](http://steamcommunity.com/profiles/76561198014050007).
+TF2 Tower Defense was originally created by [floube](http://steamcommunity.com/profiles/76561198051789304/) and [mani](http://steamcommunity.com/profiles/76561198002201102/). 
+
+It was last maintained by [Hurp Durp](http://steamcommunity.com/profiles/76561198014050007).
+
+[Dragonisser](http://steamcommunity.com/profiles/76561198039140852) is currently looking at issues/enhancements/tweaks.
+
+<hr>
 
 Plugin - [floube](http://steamcommunity.com/profiles/76561198051789304/), [Benedevil](http://steamcommunity.com/profiles/76561198056589941), [Hurp Durp](http://steamcommunity.com/profiles/76561198014050007)
  
 Maps - [mani](http://steamcommunity.com/profiles/76561198002201102/), [fatboy](http://steamcommunity.com/profiles/76561197994348901/), [Berry](http://steamcommunity.com/profiles/76561198030362593/)
+
 
 ### Requirements ###
 
@@ -36,4 +43,4 @@ Maps - [mani](http://steamcommunity.com/profiles/76561198002201102/), [fatboy](h
 8. Start your server with the map `td_firstone_v11b`. You should be able to connect and play if everything was set up correctly.
 
 
-##### Trouble getting it working? Create an issue and provide your server log files for assistance. #####
+##### Trouble getting it working? Create an issue and provide your server log files and other required information for assistance. #####

--- a/addons/sourcemod/schema/tf2td.sql
+++ b/addons/sourcemod/schema/tf2td.sql
@@ -60,7 +60,7 @@ CREATE TABLE `map` (
   `teleport_air` varchar(128) NOT NULL COMMENT 'Location of air waves.',
   `teleport_tower` varchar(128) NOT NULL COMMENT 'Location of the tower after bought.',
   `respawn_wave_time` int(11) NOT NULL COMMENT 'Time between waves (in seconds).',
-  `player_limit` int(11) NOT NULL DEFAULT '4',
+  `player_limit` int(11) NOT NULL DEFAULT '6',
   `wave_start` int(11) NOT NULL COMMENT 'The wave index to start with.',
   `wave_end` int(11) NOT NULL COMMENT 'The wave index to end with.'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/addons/sourcemod/scripting/include/steamtools.inc
+++ b/addons/sourcemod/scripting/include/steamtools.inc
@@ -6,7 +6,7 @@
 #define USE_CUSTOM_STEAMID -1
 
 /**
- * Called after SteamTools has completely finished loading. 
+ * Called after SteamTools has completely finished loading.
  * No features are available before this point.
  *
  * @noreturn
@@ -25,19 +25,19 @@ native bool:Steam_IsVACEnabled();
 /**
  * Gets the server's external IP address, as reported by Steam.
  *
- * @param octets Reference to an array to be filled with the octets of 
+ * @param octets Reference to an array to be filled with the octets of
  *               the IP address.
- * 
+ *
  * @noreturn
  */
 native Steam_GetPublicIP(octets[4]);
 
 
 /**
- * Is fired when the Steam master servers report that your server is 
+ * Is fired when the Steam master servers report that your server is
  * outdated
  *
- * @return Plugin_Continue to continue normal operation or Plugin_Handled 
+ * @return Plugin_Continue to continue normal operation or Plugin_Handled
  *         to block the regular console message.
  */
 forward Action:Steam_RestartRequested();
@@ -50,22 +50,22 @@ forward Action:Steam_RestartRequested();
  * @param client         Client index.
  * @param groupAccountID 32-bit account ID of group.
  *
- * @return A bool representing whether or not the request was sent to 
+ * @return A bool representing whether or not the request was sent to
  *         Steam.
  */
 native bool:Steam_RequestGroupStatus(client, groupAccountID);
 
 /**
  * Called when a response to a group status request is recieved.
- * This is called for all responses recieved, not just ones requested by 
+ * This is called for all responses recieved, not just ones requested by
  * your plugin.
  *
  * @param client         Client index.
- * @param groupAccountID 32-bit account ID of group. Make sure to check 
+ * @param groupAccountID 32-bit account ID of group. Make sure to check
  *                       this agaist the ID you are expecting.
- * @param groupMember    Whether or not the client is a member in the 
+ * @param groupMember    Whether or not the client is a member in the
  *                       specified group.
- * @param groupMember    Whether or not the client is an officer in the 
+ * @param groupMember    Whether or not the client is an officer in the
  *                       specified group.
  *
  * @noreturn
@@ -76,13 +76,13 @@ forward Steam_GroupStatusResult(client, groupAccountID, bool:groupMember, bool:g
 native Steam_RequestGameplayStats();
 forward Steam_GameplayStats(rank, totalConnects, totalMinutesPlayed);
 
-
+#pragma deprecated No longer operational
 native Steam_RequestServerReputation();
 forward Steam_Reputation(reputationScore, bool:banned, bannedIP, bannedPort, bannedGameID, banExpires);
 
 
 /**
- * Gets the current Steam connection state, the forwards below fire 
+ * Gets the current Steam connection state, the forwards below fire
  * whenever this changes.
  *
  * @return Steam connection state.
@@ -102,7 +102,7 @@ forward Steam_SteamServersConnected();
  * Is also fired for late-loaded plugins.
  *
  * For plugins loaded with the server, this will normally be fired right
- * after Steam_FullyLoaded, closly followed by Steam_SteamServersConnected 
+ * after Steam_FullyLoaded, closly followed by Steam_SteamServersConnected
  * if a successfull connection is established.
  *
  * @noreturn
@@ -110,13 +110,13 @@ forward Steam_SteamServersConnected();
 forward Steam_SteamServersDisconnected();
 
 /**
- * Sets an entry in the server's list of rules. This list is used to 
- * build the response to the A2S_RULES query and is generally known as 
+ * Sets an entry in the server's list of rules. This list is used to
+ * build the response to the A2S_RULES query and is generally known as
  * the list of public convars.
  *
  * @param key   Name of the key to set, is created if it does not already
  *              exist.
- * @param value Value of the key to set, the named key is removed if this 
+ * @param value Value of the key to set, the named key is removed if this
  *              is blank.
  *
  * @noreturn
@@ -124,8 +124,8 @@ forward Steam_SteamServersDisconnected();
 native Steam_SetRule(const String:key[], const String:value[]);
 
 /**
- * Clears the server's list of rules. This list is used to build the 
- * response to the A2S_RULES query and is generally known as the list of 
+ * Clears the server's list of rules. This list is used to build the
+ * response to the A2S_RULES query and is generally known as the list of
  * public convars.
  *
  * @noreturn
@@ -257,7 +257,7 @@ enum HTTPStatusCode
 	HTTPStatusCode_UnsupportedMediaType =			415,
 	HTTPStatusCode_RequestedRangeNotSatisfiable =	416,
 	HTTPStatusCode_ExpectationFailed =				417,
-	
+
 	// Server error codes
 	HTTPStatusCode_InternalServerError =			500,
 	HTTPStatusCode_NotImplemented =					501,
@@ -267,10 +267,10 @@ enum HTTPStatusCode
 	HTTPStatusCode_HTTPVersionNotSupported =		505,
 };
 
-funcenum HTTPRequestComplete
+typeset HTTPRequestComplete
 {
-	public(HTTPRequestHandle:HTTPRequest, bool:requestSuccessful, HTTPStatusCode:statusCode),
-	public(HTTPRequestHandle:HTTPRequest, bool:requestSuccessful, HTTPStatusCode:statusCode, any:contextData),
+	function Action (HTTPRequestHandle HTTPRequest, bool requestSuccessful, HTTPStatusCode statusCode);
+	function Action (HTTPRequestHandle HTTPRequest, bool requestSuccessful, HTTPStatusCode statusCode, any contextData);
 };
 
 native HTTPRequestHandle:Steam_CreateHTTPRequest(HTTPMethod:HTTPRequestMethod, const String:absoluteURL[]);
@@ -288,8 +288,9 @@ native Steam_WriteHTTPResponseBody(HTTPRequestHandle:HTTPRequest, const String:f
 native Steam_ReleaseHTTPRequest(HTTPRequestHandle:HTTPRequest);
 native Float:Steam_GetHTTPDownloadProgressPercent(HTTPRequestHandle:HTTPRequest);
 native bool:Steam_SetHTTPRequestRawPostBody(HTTPRequestHandle:HTTPRequest, const String:data[], dataLength, const String:contentType[]="text/plain");
+native bool:Steam_SetHTTPRequestRawPostBodyFile(HTTPRequestHandle:HTTPRequest, const String:filePath[], const String:contentType[]="text/plain");
 
-public Extension:__ext_SteamTools = 
+public Extension:__ext_SteamTools =
 {
 	name = "SteamTools",
 	file = "steamtools.ext",

--- a/addons/sourcemod/scripting/towerdefense.sp
+++ b/addons/sourcemod/scripting/towerdefense.sp
@@ -19,8 +19,8 @@
 #define PLUGIN_NAME		"TF2 Tower Defense"
 #define PLUGIN_AUTHOR	"floube, benedevil, hurpdurp, dragonisser"
 #define PLUGIN_DESC		"Stop enemies from crossing a map by buying towers and building up defenses."
-#define PLUGIN_VERSION	"2.1"
-#define PLUGIN_URL		"https://github.com/Dragonisser/towerdefense"
+#define PLUGIN_VERSION	"2.1.0"
+#define PLUGIN_URL		"https://github.com/tf2td/towerdefense"
 #define PLUGIN_PREFIX	"[TF2TD]"
 
 /*==========================================

--- a/addons/sourcemod/scripting/towerdefense.sp
+++ b/addons/sourcemod/scripting/towerdefense.sp
@@ -17,10 +17,10 @@
 =================================*/
 
 #define PLUGIN_NAME		"TF2 Tower Defense"
-#define PLUGIN_AUTHOR	"floube, benedevil, hurpdurp"
+#define PLUGIN_AUTHOR	"floube, benedevil, hurpdurp, dragonisser"
 #define PLUGIN_DESC		"Stop enemies from crossing a map by buying towers and building up defenses."
-#define PLUGIN_VERSION	"2.0.2"
-#define PLUGIN_URL		"https://github.com/tf2td/towerdefense"
+#define PLUGIN_VERSION	"2.1"
+#define PLUGIN_URL		"https://github.com/Dragonisser/towerdefense"
 #define PLUGIN_PREFIX	"[TF2TD]"
 
 /*==========================================

--- a/addons/sourcemod/scripting/towerdefense/database/player.sp
+++ b/addons/sourcemod/scripting/towerdefense/database/player.sp
@@ -63,15 +63,34 @@ public void Database_OnCheckPlayer(Handle hDriver, Handle hResult, const char[] 
  */
 
 stock void Database_AddPlayer(int iUserId) {
-	char sQuery[128];
+	char sQuery[256];
 	char sSteamId[32];
+	char sPlayerName[MAX_NAME_LENGTH + 1];
+	char sPlayerNameSave[MAX_NAME_LENGTH * 2 + 1];
+	char sPlayerIp[16];
+	char sPlayerIpSave[33];
+	
+	int iClient = GetClientOfUserId(iUserId);
+	
+	GetClientName(iClient, sPlayerName, sizeof(sPlayerName));
+	SQL_EscapeString(g_hDatabase, sPlayerName, sPlayerNameSave, sizeof(sPlayerNameSave));
 	
 	Player_UGetString(iUserId, PLAYER_COMMUNITY_ID, sSteamId, sizeof(sSteamId));
+
+	Player_UGetString(iUserId, PLAYER_IP_ADDRESS, sPlayerIp, sizeof(sPlayerIp));
+	SQL_EscapeString(g_hDatabase, sPlayerIp, sPlayerIpSave, sizeof(sPlayerIpSave));
 	
+
+	PrintToServer("name: (%s)", sPlayerNameSave);
+	PrintToServer("steamid: (%s)", sSteamId);
+	PrintToServer("ip: (%s)", sPlayerIpSave);
+	PrintToServer("serverid: (%d)", g_iServerId);
+
+
 	Format(sQuery, sizeof(sQuery), "\
-		INSERT INTO `player` (`steamid64`, `first_server`) \
-		VALUES ('%s', %d) \
-	", sSteamId, g_iServerId);
+		INSERT INTO `player` (`name`,`steamid64`,`ip`,`first_server`) \
+		VALUES ('%s', '%s', '%s', %d) \
+	", sPlayerNameSave, sSteamId, sPlayerIpSave, g_iServerId);
 	
 	SQL_TQuery(g_hDatabase, Database_OnAddPlayer_1, sQuery, iUserId);
 }

--- a/addons/sourcemod/scripting/towerdefense/events.sp
+++ b/addons/sourcemod/scripting/towerdefense/events.sp
@@ -341,7 +341,7 @@ public Action TF2_CalcIsAttackCritical(int iClient, int iWeapon, char[] sClassna
 		SetEntData(iWeapon, FindSendPropInfo("CTFWeaponBase", "m_iClip1"), 100, _, true);
 		SetEntData(iClient, FindSendPropInfo("CTFPlayer", "m_iAmmo") + 4, 100);
 		SetEntData(iClient, FindSendPropInfo("CTFPlayer", "m_iAmmo") + 8, 100);
-		SetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (3 * 4), 100);
+		SetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (3 * 4), 100);
 	}
 	
 	//Calculate crit chances

--- a/addons/sourcemod/scripting/towerdefense/handler/aoe.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/aoe.sp
@@ -37,6 +37,7 @@ public Action Timer_ClientNearAoETower(Handle hTimer) {
 			}
 		}
 	}
+	return Plugin_Continue;
 }
 
 /**
@@ -292,6 +293,7 @@ public Action Timer_TeleportAoEEngineerBack(Handle hTimer, DataPack hPack) {
 	fLocation[1] = hPack.ReadFloat();
 	fLocation[2] = hPack.ReadFloat();
 	TeleportEntity(iTower, fLocation, NULL_VECTOR, NULL_VECTOR);
+	return Plugin_Continue;
 }
 
 /**

--- a/addons/sourcemod/scripting/towerdefense/handler/corners.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/corners.sp
@@ -213,7 +213,7 @@ stock bool Corner_GetAngles(int iCornerA, int iCornerB, float fAngles[3], bool b
  * @return				The next corners entity index, or -1 on failure.
  */
 
-stock int Corner_GetNext(int iCorner = -1, const char sName[] = "") {
+stock int Corner_GetNext(int iCorner = -1, const char[] sName = "") {
 	char sCornerName[64];
 	
 	if (StrEqual(sName, "") && Corner_IsValid(iCorner)) {
@@ -243,7 +243,7 @@ stock int Corner_GetNext(int iCorner = -1, const char sName[] = "") {
  * @return				The previous corners entity index, or -1 on failure.
  */
 
-stock void Corner_GetPrevious(int iCorner = -1, const char sName[] = "") {
+stock int Corner_GetPrevious(int iCorner = -1, const char[] sName = "") {
 	char sCornerName[64];
 	
 	if (StrEqual(sName, "") && Corner_IsValid(iCorner)) {

--- a/addons/sourcemod/scripting/towerdefense/handler/metalpacks.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/metalpacks.sp
@@ -70,7 +70,7 @@ stock bool SpawnMetalPacks(TDMetalPackType iMetalPackType) {
  * @return					True on success, false otherwiseherwise.
  */
 
-stock bool SpawnMetalPacksNumber(TDMetalPackType iMetalPackType, int iNumPacks) {
+stock void SpawnMetalPacksNumber(TDMetalPackType iMetalPackType, int iNumPacks) {
 	
 	int iMetal = 0, iEntity;
 	float fLocation[3];
@@ -113,7 +113,7 @@ stock bool SpawnMetalPacksNumber(TDMetalPackType iMetalPackType, int iNumPacks) 
  * @noreturn
  */
 
-stock void SpawnRewardPack(TDMetalPackSpawnType iMetalPackType, float[3] fLocation, int iMetal) {
+stock void SpawnRewardPack(TDMetalPackSpawnType iMetalPackType, float fLocation[3], int iMetal) {
 	int iEntity;
 	SpawnMetalPack2(iMetalPackType, fLocation, iMetal, iEntity);
 	

--- a/addons/sourcemod/scripting/towerdefense/handler/player.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/player.sp
@@ -77,6 +77,36 @@ stock void Player_SyncDatabase(int iUserId, int iClient, const char[] sCommunity
 stock void Player_Connected(int iUserId, int iClient, const char[] sName, const char[] sSteamId, const char[] sCommunityId, const char[] sIp) {
 	Log(TDLogLevel_Debug, "Player connected (UserId=%d, Client=%d, Name=%s, SteamId=%s, CommunityId=%s, Address=%s)", iUserId, iClient, sName, sSteamId, sCommunityId, sIp);
 	
+	char sQuery[256];
+	char sCurrentMap[PLATFORM_MAX_PATH];
+	GetCurrentMap(sCurrentMap, sizeof(sCurrentMap));
+
+	int maxClientMap = PLAYER_LIMIT;
+
+	Format(sQuery, sizeof(sQuery), "\
+		SELECT `map_id`, `respawn_wave_time` \
+		FROM `map` \
+		WHERE `name` = '%s' \
+		LIMIT 1 \
+	", sCurrentMap);
+	
+	DBResultSet query = SQL_Query(g_hDatabase, sQuery);
+
+	if (query == null)
+	{
+		char error[255];
+		SQL_GetError(g_hDatabase, error, sizeof(error));
+		LogType(TDLogLevel_Error, TDLogType_FileAndConsole, "Failed to query (error: %s)", error);
+	} 
+	else 
+	{
+		//TODO
+		//check the maxplayer for the map
+		//maxClientMap = GetData....
+		delete query;
+	}
+
+
 	if (!StrEqual(sSteamId, "BOT")) {
 		if (GetRealClientCount() > PLAYER_LIMIT) {
 			KickClient(iClient, "Maximum number of players has been reached (%d/%d)", GetRealClientCount() - 1, PLAYER_LIMIT);

--- a/addons/sourcemod/scripting/towerdefense/handler/player.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/player.sp
@@ -76,45 +76,15 @@ stock void Player_SyncDatabase(int iUserId, int iClient, const char[] sCommunity
 
 stock void Player_Connected(int iUserId, int iClient, const char[] sName, const char[] sSteamId, const char[] sCommunityId, const char[] sIp) {
 	Log(TDLogLevel_Debug, "Player connected (UserId=%d, Client=%d, Name=%s, SteamId=%s, CommunityId=%s, Address=%s)", iUserId, iClient, sName, sSteamId, sCommunityId, sIp);
-	
-	char sQuery[256];
-	char sCurrentMap[PLATFORM_MAX_PATH];
-	GetCurrentMap(sCurrentMap, sizeof(sCurrentMap));
-
-	int maxClientMap = PLAYER_LIMIT;
-
-	Format(sQuery, sizeof(sQuery), "\
-		SELECT `map_id`, `respawn_wave_time` \
-		FROM `map` \
-		WHERE `name` = '%s' \
-		LIMIT 1 \
-	", sCurrentMap);
-	
-	DBResultSet query = SQL_Query(g_hDatabase, sQuery);
-
-	if (query == null)
-	{
-		char error[255];
-		SQL_GetError(g_hDatabase, error, sizeof(error));
-		LogType(TDLogLevel_Error, TDLogType_FileAndConsole, "Failed to query (error: %s)", error);
-	} 
-	else 
-	{
-		//TODO
-		//check the maxplayer for the map
-		//maxClientMap = GetData....
-		delete query;
-	}
-
 
 	if (!StrEqual(sSteamId, "BOT")) {
-		if (GetRealClientCount() > PLAYER_LIMIT) {
-			KickClient(iClient, "Maximum number of players has been reached (%d/%d)", GetRealClientCount() - 1, PLAYER_LIMIT);
-			Log(TDLogLevel_Info, "Kicked player (%N, %s) (Maximum players reached: %d/%d)", iClient, sSteamId, GetRealClientCount() - 1, PLAYER_LIMIT);
+		if (GetRealClientCount() > g_iMaxClients) {
+			KickClient(iClient, "Maximum number of players has been reached (%d/%d)", GetRealClientCount() - 1, g_iMaxClients);
+			Log(TDLogLevel_Info, "Kicked player (%N, %s) (Maximum players reached: %d/%d)", iClient, sSteamId, GetRealClientCount() - 1, g_iMaxClients);
 			return;
 		}
 		
-		Log(TDLogLevel_Info, "Connected clients: %d/%d", GetRealClientCount(), PLAYER_LIMIT);
+		Log(TDLogLevel_Info, "Connected clients: %d/%d", GetRealClientCount(), g_iMaxClients);
 		
 		Player_USetString(iUserId, PLAYER_STEAM_ID, sSteamId);
 		Player_USetString(iUserId, PLAYER_COMMUNITY_ID, sCommunityId);

--- a/addons/sourcemod/scripting/towerdefense/handler/player.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/player.sp
@@ -343,7 +343,7 @@ stock void Player_USetFloat(int iUserId, const char[] sKey, float fValue) {
 	Format(sUserIdKey, sizeof(sUserIdKey), "%d_%s", iUserId, sKey);
 	
 	char sValue[64];
-	FloatToString(fValue, sValue, sizeof(sValue))
+	FloatToString(fValue, sValue, sizeof(sValue));
 	
 	Player_OnDataSet(iUserId, GetClientOfUserId(iUserId), sKey, TDDataType_Integer, -1, false, fValue, "");
 	
@@ -376,7 +376,7 @@ stock bool Player_CGetFloat(int iClient, const char[] sKey, float &fValue) {
 	return CheckClientForUserId(iClient) && Player_UGetFloat(GetClientUserId(iClient), sKey, fValue);
 }
 
-stock bool Player_USetString(int iUserId, const char[] sKey, const char[] sValue, any...) {
+stock void Player_USetString(int iUserId, const char[] sKey, const char[] sValue, any...) {
 	char sUserIdKey[128];
 	Format(sUserIdKey, sizeof(sUserIdKey), "%d_%s", iUserId, sKey);
 	
@@ -420,7 +420,7 @@ stock void Player_AddHealth(int iClient, int iHealth, bool ignoreMax=false) {
 			SetEntityHealth(iClient, GetClientHealth(iClient) + iHealth);
 		} else {
 			int iCurrentHealth = GetEntProp(iClient, Prop_Send, "m_iHealth");
-			int iMaxHealth = GetEntData(iClient, FindDataMapOffs(iClient, "m_iMaxHealth"));
+			int iMaxHealth = GetEntData(iClient, FindDataMapInfo(iClient, "m_iMaxHealth"));
 			if(iCurrentHealth < iMaxHealth) {
 				SetEntityHealth(iClient, GetClientHealth(iClient) + iHealth);
 			}

--- a/addons/sourcemod/scripting/towerdefense/handler/server.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/server.sp
@@ -158,6 +158,41 @@ stock void Server_Reset() {
 		hAoETimer = null;
 	}
 
+	//Get map max clients
+	g_iMaxClients = PLAYER_LIMIT;
+
+	char sQuery[256];
+	char sCurrentMap[PLATFORM_MAX_PATH];
+	GetCurrentMap(sCurrentMap, sizeof(sCurrentMap));
+
+	Format(sQuery, sizeof(sQuery), "\
+		SELECT `player_limit` \
+		FROM `map` \
+		WHERE `name` = '%s' \
+		LIMIT 1 \
+	", sCurrentMap);
+	
+	DBResultSet queryResult = SQL_Query(g_hDatabase, sQuery);
+
+	if (queryResult == null)
+	{
+		char error[255];
+		SQL_GetError(g_hDatabase, error, sizeof(error));
+		LogType(TDLogLevel_Error, TDLogType_FileAndConsole, "Failed to query (error: %s)", error);
+	} 
+	else 
+	{
+		if(queryResult.HasResults && queryResult.FetchRow()) {
+			if (queryResult.FetchInt(0) > 0) {
+				g_iMaxClients = queryResult.FetchInt(0);
+				LogType(TDLogLevel_Debug, TDLogType_FileAndConsole, "Max clients for map %s is %d", sCurrentMap, g_iMaxClients);
+			} 
+		} else {
+				LogType(TDLogLevel_Debug, TDLogType_FileAndConsole, "Couldn't find entry for map '%s'. Setting max clients to default %d", sCurrentMap, g_iMaxClients);
+			}
+		delete queryResult;
+	}
+
 	Format(g_sPassword, sizeof(g_sPassword), "");
 
 	SetPassword(g_sPassword, false); //Change upon release

--- a/addons/sourcemod/scripting/towerdefense/handler/server.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/server.sp
@@ -259,7 +259,7 @@ stock void Server_USetFloat(int iServerId, const char[] sKey, float fValue) {
 	Format(sServerIdKey, sizeof(sServerIdKey), "%d_%s", iServerId, sKey);
 
 	char sValue[64];
-	FloatToString(fValue, sValue, sizeof(sValue))
+	FloatToString(fValue, sValue, sizeof(sValue));
 
 	Server_OnDataSet(iServerId, sKey, TDDataType_Integer, -1, false, fValue, "");
 
@@ -282,7 +282,7 @@ stock bool Server_UGetFloat(int iServerId, const char[] sKey, float &fValue) {
 	return true;
 }
 
-stock bool Server_USetString(int iServerId, const char[] sKey, const char[] sValue, any...) {
+stock void Server_USetString(int iServerId, const char[] sKey, const char[] sValue, any...) {
 	char sServerIdKey[128];
 	Format(sServerIdKey, sizeof(sServerIdKey), "%d_%s", iServerId, sKey);
 

--- a/addons/sourcemod/scripting/towerdefense/handler/waves.sp
+++ b/addons/sourcemod/scripting/towerdefense/handler/waves.sp
@@ -319,7 +319,6 @@ stock void Wave_SpawnBots() {
 	if(g_iBotsToSpawn <= 0) {
 		return;
 	}
-	
 	char sName[MAX_NAME_LENGTH];
 	if (!Wave_GetName(g_iCurrentWave, sName, sizeof(sName))) {
 		LogType(TDLogLevel_Error, TDLogType_FileAndConsole, "Failed to spawn wave %d, could not read name!", g_iCurrentWave);

--- a/addons/sourcemod/scripting/towerdefense/info/constants.sp
+++ b/addons/sourcemod/scripting/towerdefense/info/constants.sp
@@ -1,6 +1,6 @@
 #define GAME_DESCRIPTION "Tower Defense"
 
-#define PLAYER_LIMIT 4
+#define PLAYER_LIMIT 6
 #define METALPACK_LIMIT 50
 
 #define TEAM_DEFENDER 3

--- a/addons/sourcemod/scripting/towerdefense/info/variables.sp
+++ b/addons/sourcemod/scripting/towerdefense/info/variables.sp
@@ -49,6 +49,7 @@ int iMaxWaves;
 int iMaxMultiplierTypes;
 int g_iBotsToSpawn;
 int g_iTotalBotsLeft;
+int g_iMaxClients;
 
 /*==========  String  ==========*/
 

--- a/addons/sourcemod/scripting/towerdefense/timers.sp
+++ b/addons/sourcemod/scripting/towerdefense/timers.sp
@@ -23,16 +23,21 @@ public Action Timer_Hints(Handle hTimer) {
 		PrintToChatAll("\x04[\x03TD\x04]\x03 Check on what wave you're on with \x04/w ");
 	else if(iRandom  == 6)
 		PrintToChatAll("\x04[\x03TD\x04]\x03 Dying will make you lose half your metal! ");
+	return Plugin_Continue;
 }
 public Action Timer_Reset(Handle hTimer) {
 	SetPassword("", true, true);
+	return Plugin_Continue;
 }
 
 public Action RespawnPlayer(Handle hTimer, any iClient) {
-	if(IsValidClient(iClient))
+	if(IsValidClient(iClient)) {
 		TF2_RespawnPlayer(iClient);
+	}
+	return Plugin_Continue;
 }
 
 public Action Timer_EnableUnlockButton(Handle hTimer) {
 	g_bCanGetUnlocks = true;
+	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/towerdefense/util/metal.sp
+++ b/addons/sourcemod/scripting/towerdefense/util/metal.sp
@@ -16,7 +16,7 @@
  */
 
 stock int GetClientMetal(int iClient) {
-	return GetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (3 * 4), 4);
+	return GetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (3 * 4), 4);
 }
 
 /**
@@ -28,7 +28,7 @@ stock int GetClientMetal(int iClient) {
  */
 
 stock void SetClientMetal(int iClient, int iMetal) {
-	SetEntData(iClient, FindDataMapOffs(iClient, "m_iAmmo") + (3 * 4), iMetal, 4);
+	SetEntData(iClient, FindDataMapInfo(iClient, "m_iAmmo") + (3 * 4), iMetal, 4);
 	
 	Log(TDLogLevel_Trace, "Set %N's metal to %d", iClient, iMetal);
 }

--- a/addons/sourcemod/scripting/towerdefense/util/zones.sp
+++ b/addons/sourcemod/scripting/towerdefense/util/zones.sp
@@ -19,7 +19,7 @@
  * @noreturn
  */
 
-stock void CreateBeamLine(int iClient, float fStart[3], float fEnd[3], float fDuration = 5.0, const int iColors[] =  { 255, 0, 0, 255 } ) {
+stock void CreateBeamLine(int iClient, float fStart[3], float fEnd[3], float fDuration = 5.0, const int[] iColors =  { 255, 0, 0, 255 } ) {
 	int iColors2[4];
 	iColors2[0] = iColors[0];
 	iColors2[1] = iColors[1];
@@ -151,7 +151,7 @@ public Action:Timer_CreateBeam2(Handle:hTimer, Handle:hPack) {
  * @noreturn
  */
 
-stock void CreateBeamBox(int iClient, float fStart[3], float fEnd[3], float fDuration = 5.0, const int iColors[] =  { 255, 0, 0, 255 } ) {
+stock void CreateBeamBox(int iClient, float fStart[3], float fEnd[3], float fDuration = 5.0, const int[] iColors =  { 255, 0, 0, 255 } ) {
 	float fPoint[8][3];
 	
 	CopyVector(fStart, fPoint[0]);
@@ -227,7 +227,7 @@ stock void CreateZonePoints(float fPoint[8][3]) {
  * @noreturn
  */
 
-stock void CreateBeamBoxAroundClient(int iClient, float fDistance, bool OnlyPlayerHeight = true, float fDuration = 5.0, const int iColors[] =  { 255, 0, 0, 255 } ) {
+stock void CreateBeamBoxAroundClient(int iClient, float fDistance, bool OnlyPlayerHeight = true, float fDuration = 5.0, const int[] iColors =  { 255, 0, 0, 255 } ) {
 	if (!IsValidClient(iClient) || !IsClientConnected(iClient) || !IsClientInGame(iClient) || !IsPlayerAlive(iClient)) {
 		return;
 	}
@@ -348,8 +348,10 @@ stock bool IsClientInZone(int iClient, float fPoint[8][3]) {
  * @return				True if inside, false otherwise.
  */
 
-stock bool IsClientInZone2(int iClient, float fPoint[8][3], int iID) {
-	float fPlayerPosition[3], Float fPlayerPoint[8][3];
+/*stock bool IsClientInZone2(int iClient, float fPoint[8][3], int iID) {
+
+	float fPlayerPosition[3];
+	float fPlayerPoint[8][3];
 	
 	GetEntPropVector(iClient, Prop_Send, "m_vecOrigin", fPlayerPosition);
 	fPlayerPosition[2] += 41.5;
@@ -364,7 +366,7 @@ stock bool IsClientInZone2(int iClient, float fPoint[8][3], int iID) {
 	CreateZonePoints(fPlayerPoint);
 	
 	return (Box3DIntersects(fPlayerPoint, fPoint) && g_bMetalPackID[iID]);
-}
+}*/
 
 /**
  * Draws a bounding box around a client.


### PR DESCRIPTION
- Tweak: Max clients connected is by default 6
- Tweak: Max clients connected is read from the database table "map", specifically the column "player_limit".
- Tweak: General clean-up of warnings and errors in the code, as well as updating the syntax to SM 1.11 (like steamtools.inc)
- Fix: new players will now be added the "player" table in the database.

Dependencies are still the same