### PR TITLE
fix: sql syntax

### DIFF
--- a/addons/sourcemod/schema/001_update.sql
+++ b/addons/sourcemod/schema/001_update.sql
@@ -192,5 +192,5 @@ INSERT INTO `wave` (`wave_id`, `wavetype`, `name`, `class`, `quantity`, `health`
 (127, 36, 'OverpoweredMedic', 'Medic', 8, 10975),
 (128, 8, 'floube', 'Engineer', 9, 9975),
 (129, 8, 'mani', 'Soldier', 10, 9975),
-(130, 37, 'benedevil', 'Heavy', 4, 60000);
+(130, 37, 'benedevil', 'Heavy', 4, 60000),
 (131, 7, 'dragonisser', 'Medic', 12, 8000);

--- a/addons/sourcemod/schema/tf2td.sql
+++ b/addons/sourcemod/schema/tf2td.sql
@@ -644,7 +644,7 @@ INSERT INTO `wave` (`wave_id`, `wavetype`, `name`, `class`, `quantity`, `health`
 (127, 36, 'OverpoweredMedic', 'Medic', 8, 10975),
 (128, 8, 'floube', 'Engineer', 9, 9975),
 (129, 8, 'mani', 'Soldier', 10, 9975),
-(130, 37, 'benedevil', 'Heavy', 4, 60000);
+(130, 37, 'benedevil', 'Heavy', 4, 60000),
 (131, 7, 'dragonisser', 'Medic', 12, 8000);
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Fixes the incorrect sql syntax in both the update schema and the base one.

Fixes https://github.com/tf2td/towerdefense/issues/33